### PR TITLE
The keyboard remains visible when the menu is opened.

### DIFF
--- a/FlyOutNavigation/FlyOutNavigationController.cs
+++ b/FlyOutNavigation/FlyOutNavigationController.cs
@@ -252,10 +252,22 @@ namespace FlyOutNavigation
 		{
 			shadowView.RemoveFromSuperview();
 		}
+
+		public void ResignFirstResponders(UIView view)
+		{
+			foreach(var subview in view.Subviews)
+			{
+				if (subview.IsFirstResponder)
+					subview.ResignFirstResponder();
+				ResignFirstResponders(subview);
+			}
+		}
 		
 		public void ToggleMenu()
 		{
 			EnsureInvokedOnMainThread(delegate{
+				if(!isOpen && CurrentViewController != null && CurrentViewController.IsViewLoaded)
+					ResignFirstResponders(CurrentViewController.View);
 				if(isOpen)
 					HideMenu();
 				else


### PR DESCRIPTION
It's just a style preference, but I figured I'd offer it back.  Thanks for creating this.

I put the subview traversal in the main thread.
Should only line 261 (subview.ResignFirstResponder();) be in EnsureInvokedOnMainThread?
