### PR TITLE
UINavigationBar doesn't resize height when iPhone is rotated

### DIFF
--- a/FlyOutNavigation/FlyOutNavigationController.cs
+++ b/FlyOutNavigation/FlyOutNavigationController.cs
@@ -347,6 +347,14 @@ namespace FlyOutNavigation
 			}
 			
 		}
+
+		public override void WillAnimateRotation (UIInterfaceOrientation toInterfaceOrientation, double duration)
+		{
+			base.WillAnimateRotation (toInterfaceOrientation, duration);
+			if(CurrentViewController != null)
+				CurrentViewController.WillAnimateRotation(toInterfaceOrientation, duration);
+		}
+
 		private void EnsureInvokedOnMainThread (Action action)
 		{
 			if (IsMainThread ())


### PR DESCRIPTION
When you rotate an iPhone to landscape mode the navigation bar is resized to be shorter.  Since this isn't happening, the top part of the content view's contents are obscured beneath it.  Additionally if a new view controller is opened while in landscape mode, the navigation bar's height is set correctly, but, upon rotation to portrait mode, the nav bar isn't resized and there is a gap between it and the content view.
