### PR TITLE
Use modern C# idioms

### DIFF
--- a/FlyoutNavigation/FlyoutNavigation.csproj
+++ b/FlyoutNavigation/FlyoutNavigation.csproj
@@ -36,16 +36,11 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="monotouch" />
+    <Reference Include="MonoTouch.Dialog-1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <Compile Include="OpenMenuGestureRecognizer.cs" />
     <Compile Include="FlyoutNavigationController.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\MonoTouch.Dialog\MonoTouch.Dialog\MonoTouch.Dialog.csproj">
-      <Project>{3FFBFFF8-5560-4EDE-82E5-3FFDFBBA8A50}</Project>
-      <Name>MonoTouch.Dialog</Name>
-    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/FlyoutNavigation/FlyoutNavigationController.cs
+++ b/FlyoutNavigation/FlyoutNavigationController.cs
@@ -209,7 +209,7 @@ namespace FlyoutNavigation
 			closeButton.TouchUpInside += delegate { HideMenu(); };
 			AlwaysShowLandscapeMenu = true;
 
-			View.AddGestureRecognizer(new OpenMenuGestureRecognizer(this, new Selector("panned"), this));
+			View.AddGestureRecognizer (new OpenMenuGestureRecognizer (DragContentView, shouldReceiveTouch));
 		}
 
 		public event UITouchEventArgs ShouldReceiveTouch;
@@ -233,7 +233,6 @@ namespace FlyoutNavigation
 				navigation.View.Frame = navFrame;
 		}
 
-		[Export("panned")]
 		public void DragContentView(UIPanGestureRecognizer panGesture)
 		{
 			//Console.WriteLine("drag flyout");

--- a/FlyoutNavigation/OpenMenuGestureRecognizer.cs
+++ b/FlyoutNavigation/OpenMenuGestureRecognizer.cs
@@ -22,16 +22,14 @@ namespace FlyoutNavigation
 {
 	public class OpenMenuGestureRecognizer : UIPanGestureRecognizer
 	{
-		FlyoutNavigationController Parent;
-		public OpenMenuGestureRecognizer (NSObject target, Selector action,FlyoutNavigationController parent) : base(target,action)
+		public OpenMenuGestureRecognizer (Action<UIPanGestureRecognizer> callback, Func<UIGestureRecognizer, UITouch,bool>  shouldReceiveTouch) : base (callback)
 		{
-			Parent = parent;
 			this.ShouldReceiveTouch += (sender,touch)=> {
 				//Ugly hack to ignore touches that are on a cell that is moving...
 				bool isMovingCell = touch.View.ToString().IndexOf("UITableViewCellReorderControl",StringComparison.InvariantCultureIgnoreCase) > -1;
 				if(touch.View is UISlider || touch.View is MPVolumeView || isMovingCell)
 					return false;
-				return Parent.shouldReceiveTouch(sender,touch);
+				return shouldReceiveTouch(sender,touch);
 			};
 		}
 	}


### PR DESCRIPTION
We want to discourage users from using the target/action pattern as it is error prone.

One particular incorrect use is your code that exports a selector here for a function that takes an argument, but does not specify that an argument is expected (missing the ':' in the selector).

This fixed both issues.
